### PR TITLE
serve from /dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ uv venv && source .venv/bin/activate
 uv run python start_dashboard.py --source-dir /home/<username>/path/to/layer-values-monitor/logs/ --port 8000
 ```
 
-4. **Open your browser** and go to: `http://localhost:8000` (or your custom port)
+4. **Open your browser** and go to: `http://localhost:8000/dashboard/` (or your custom port)
 
 ## Usage
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ import re
 # Configuration
 SOURCE_DIR = os.getenv('LAYER_SOURCE_DIR', 'source_tables')
 
-app = FastAPI(title="Layer Values Dashboard", version="1.0.0")
+app = FastAPI(title="Layer Values Dashboard", version="1.0.0", root_path="/dashboard")
 
 # Enable CORS for frontend
 app.add_middleware(

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Layer Values Dashboard</title>
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="./static/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -222,6 +222,6 @@
         </div>
     </div>
 
-    <script src="/static/app.js"></script>
+    <script src="./static/app.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
Changes to expect serving static assets to `/dashboard` instead of `/` on the configured port.